### PR TITLE
软件启动时初始化数据库，防止因为删除数据库db文件导致程序无法运行

### DIFF
--- a/AppTime/AppTime.csproj
+++ b/AppTime/AppTime.csproj
@@ -92,6 +92,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InitDB.cs" />
     <Compile Include="WinApi.cs" />
     <Compile Include="Controller.cs" />
     <Compile Include="DB.cs" />

--- a/AppTime/InitDB.cs
+++ b/AppTime/InitDB.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AppTime
+{
+    /**
+     * 初始化数据库
+     */
+    class InitDB
+    {
+        private DB db;
+
+        public InitDB()
+        {
+            db = DB.Instance;
+        }
+
+        public void Start()
+        {
+            // 创建数据表
+
+            db.Execute("CREATE TABLE IF NOT EXISTS \"app\" (\"id\" INTEGER NOT NULL, \"process\" text NOT NULL," +
+                "\"text\" TEXT NOT NULL DEFAULT process, " +
+                "\"tagId\" INTEGER NOT NULL DEFAULT(0), " +
+                "PRIMARY KEY(\"id\") ) WITHOUT ROWID");
+
+            db.Execute("CREATE TABLE IF NOT EXISTS \"period\" ( \"timeStart\" DATETIME NOT NULL, \"timeEnd\" DATETIME NOT NULL, " +
+                "\"winId\" INTEGER NOT NULL," +
+                "PRIMARY KEY(\"timeStart\")," +
+                "UNIQUE(\"timeStart\" ASC) )WITHOUT ROWID");
+
+            db.Execute("CREATE TABLE IF NOT EXISTS \"tag\" ( \"id\" INTEGER NOT NULL, \"text\" TEXT NOT NULL," +
+                "PRIMARY KEY(\"id\"), UNIQUE(\"id\" ASC), UNIQUE(\"text\" ASC) ) WITHOUT ROWID");
+
+            db.Execute("CREATE TABLE IF NOT EXISTS \"win\" (\"id\" INTEGER NOT NULL," +
+                "\"appId\" INTEGER NOT NULL, \"text\" TEXT NOT NULL, " +
+                "\"tagId\" INTEGER NOT NULL DEFAULT(0), " +
+                "PRIMARY KEY(\"id\") ) WITHOUT ROWID");
+
+
+            // 创建索引
+
+            long existIndex = (long)db.ExecuteData("SELECT count(*) FROM sqlite_master WHERE type=\"table\" AND name =\'is_index\'")[0][0];
+            // 判断是否已经存在索引
+            if (existIndex == 0)
+            {
+                db.Execute("CREATE UNIQUE INDEX \"ix_app\" ON \"app\"( \"process\" ASC )");
+                db.Execute("CREATE INDEX \"ix_app_tagId\" ON \"app\" ( \"tagId\" ASC )");
+
+                db.Execute("CREATE UNIQUE INDEX \"ix_period\" ON \"period\" ( \"timeStart\" ASC, \"timeEnd\" ASC )");
+
+                db.Execute("CREATE UNIQUE INDEX \"ix_win\" ON \"win\" ( \"appId\" ASC, \"text\" ASC )");
+                db.Execute("CREATE INDEX \"ix_win_tagId\" ON \"win\" (\"tagId\" ASC )");
+
+                // 此表仅用于标识索引已经创建完成
+                db.Execute("CREATE TABLE IF NOT EXISTS \"is_index\"( \"id\" INTEGER NOT NULL, PRIMARY KEY(\"id\"))");
+            }
+        }
+    }
+}

--- a/AppTime/Program.cs
+++ b/AppTime/Program.cs
@@ -17,6 +17,7 @@ namespace AppTime
     {
 
         public const int Port = 15720;
+        public static InitDB init;
         public static Recorder recorder;
         public static WebServer server;
         public static Controller controller;
@@ -28,6 +29,9 @@ namespace AppTime
         [STAThread]
         static void Main()
         {
+            init = new InitDB();
+            init.Start();
+
             recorder = new Recorder();
             recorder.Start();
 

--- a/AppTime/Properties/Settings.Designer.cs
+++ b/AppTime/Properties/Settings.Designer.cs
@@ -49,7 +49,7 @@ namespace AppTime.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("100")]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
         public int ScreenBufferMB {
             get {
                 return ((int)(this["ScreenBufferMB"]));

--- a/AppTime/Properties/Settings.settings
+++ b/AppTime/Properties/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)">30</Value>
     </Setting>
     <Setting Name="ScreenBufferMB" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">100</Value>
+      <Value Profile="(Default)">50</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/AppTime/app.config
+++ b/AppTime/app.config
@@ -39,7 +39,7 @@
         <value>30</value>
       </setting>
       <setting name="ScreenBufferMB" serializeAs="String">
-        <value>100</value>
+        <value>50</value>
       </setting>
     </AppTime.Properties.Settings>
   </userSettings>


### PR DESCRIPTION
一点点小修改

- 软件运行时会自动创建data.db，但其中不存在表结构，在运行软件时初始化数据库表（不存在则建表，存在则不进行修改），防止因为用户误删data.db导致无法正常使用。

- 防止迭代更新版本导致原有数据丢失，因为用户在使用老版本时本地已经创建一个data.db用于存储数据，启动时检测数据库，release中无需再包含data.db，从而避免了原来的data.db被覆盖。