### PR TITLE
修复缩放及分辨率导致无法截取完整屏幕的问题

### DIFF
--- a/AppTime/app.manifest
+++ b/AppTime/app.manifest
@@ -7,5 +7,10 @@
         <requestedExecutionLevel level="asInvoker" uiAccess="false" />
       </requestedPrivileges>
     </security>
-  </trustInfo> 
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    </windowsSettings>
+  </application>
 </assembly>


### PR DESCRIPTION
应该是和 #6 一样的问题
之前电脑缩放设置为125%时无法截取完整屏幕，做了这个修改之后可以了
我在自己的电脑和显示器上测试都是OK的，不知道其他设备情况如何